### PR TITLE
fix: remove pre-operation saves that could overwrite external KDF changes

### DIFF
--- a/pykorf/use_case/web/routes/bulk_copy.py
+++ b/pykorf/use_case/web/routes/bulk_copy.py
@@ -37,7 +37,6 @@ def bulk_copy():
             error = "Please enter a reference pipe."
         else:
             try:
-                model.io.save()
                 from pykorf.use_case import copy_fluids
 
                 target_list = (
@@ -47,11 +46,12 @@ def bulk_copy():
                 )
                 updated_pipes = copy_fluids(model, ref_pipe, target_list, exclude)
                 updated_count = len(updated_pipes)
-                result = "success"
                 model.io.save()
                 _sess.reload()
+                result = "success"
             except Exception as exc:
                 error = f"Error: {exc}"
+                _sess.reload()
 
     pipes = pipe_names(model)
 

--- a/pykorf/use_case/web/routes/data.py
+++ b/pykorf/use_case/web/routes/data.py
@@ -33,8 +33,6 @@ def _apply_pms_from_source(model, pms_source: Path) -> None:
     from pykorf.use_case.config import set_pms_excel_last_imported
     from pykorf.use_case.pms import apply_pms as _apply_pms, import_pms_from_excel
 
-    model.io.save()
-
     # Convert Excel → pms.json in the data dir, then apply from JSON
     if pms_source.suffix.lower() in (".xlsx", ".xls"):
         json_path = import_pms_from_excel(pms_source)

--- a/pykorf/use_case/web/routes/global_parameters.py
+++ b/pykorf/use_case/web/routes/global_parameters.py
@@ -82,7 +82,6 @@ def global_settings():
             shutoff_margin=shutoff_margin,
         )
         try:
-            model.io.save()
             apply_results: dict[str, Any] = apply_global_settings(
                 model, selected_ids, save=False, dp_margin=dp_margin
             )
@@ -102,6 +101,7 @@ def global_settings():
         except Exception as exc:
             logger.error("global_settings_error", error=str(exc))
             errors.append(f"Error applying settings: {exc}")
+            _sess.reload()
 
     return render_template(
         "global_parameters.html",

--- a/pykorf/use_case/web/routes/pipe_criteria.py
+++ b/pykorf/use_case/web/routes/pipe_criteria.py
@@ -434,7 +434,6 @@ def pipe_criteria():
     if request.method == "POST":
         action = request.form.get("action", "set_criteria")
         logger.debug("pipe_criteria_post", action=action, kdf_path=str(kdf_path or ""))
-        model.io.save()
 
         if action == "predict":
             logger.debug("predict_action_triggered")


### PR DESCRIPTION
The pre-operation model.io.save() calls in bulk_copy, data, global_parameters,
and pipe_criteria ran BEFORE any modifications using the stale session state.
If the KDF had been edited externally (e.g. in KORF) after pyKorf loaded it,
these saves silently overwrote those external changes.

Also fixes bulk_copy.py where result="success" was set before model.io.save(),
causing a false success indicator if the save failed. Added _sess.reload() to
except blocks in bulk_copy and global_parameters to restore clean in-memory
state from the last saved disk state after a failure.

https://claude.ai/code/session_01JHc3kHxKTjU2W2L4DAgvKq