### PR TITLE
P0: Cache config in memory + atomic writes, add persist() helper

### DIFF
--- a/pykorf/app/api/deps.py
+++ b/pykorf/app/api/deps.py
@@ -33,6 +33,15 @@ async def require_model():
     return model
 
 
+async def persist(model) -> None:
+    """Save model changes to disk and reload session state.
+
+    Centralizes the save + reload pattern used by every mutating endpoint.
+    """
+    model.save()
+    await _sess.reload()
+
+
 def pipe_names(model) -> list[str]:
     """Return sorted pipe name list for tables and dropdowns.
 
@@ -45,3 +54,11 @@ def pipe_names(model) -> list[str]:
     return sorted(
         model.pipes[idx].name for idx in range(1, len(model.pipes) + 1) if model.pipes[idx].name
     )
+
+
+def is_real_pipe(pipe) -> bool:
+    """Return True if the pipe is not a dummy pipe.
+
+    Dummy pipes have names starting with 'd' (e.g. 'd1').
+    """
+    return bool(pipe.name and not pipe.name.startswith("d"))

--- a/pykorf/app/api/deps.py
+++ b/pykorf/app/api/deps.py
@@ -37,8 +37,11 @@ async def persist(model) -> None:
     """Save model changes to disk and reload session state.
 
     Centralizes the save + reload pattern used by every mutating endpoint.
+    model.save() is run in a thread to avoid blocking the event loop.
     """
-    model.save()
+    import asyncio
+
+    await asyncio.to_thread(model.save)
     await _sess.reload()
 
 

--- a/pykorf/app/operation/config/preferences.py
+++ b/pykorf/app/operation/config/preferences.py
@@ -16,6 +16,9 @@ from typing import Any
 from pykorf.app.exceptions import UseCaseError
 from pykorf.app.operation.config.paths import get_config_path
 
+# In-memory config cache to avoid reading from disk on every getter call.
+_config_cache: dict[str, Any] | None = None
+
 
 def load_config() -> dict[str, Any]:
     """Load user configuration from disk.
@@ -23,13 +26,20 @@ def load_config() -> dict[str, Any]:
     Returns:
         Dictionary of configuration values. Returns empty dict if file doesn't exist.
     """
+    global _config_cache
+    if _config_cache is not None:
+        return _config_cache.copy()
+
     config_path = get_config_path()
     if not config_path.exists():
+        _config_cache = {}
         return {}
     try:
         with open(config_path, encoding="utf-8") as f:
-            return json.load(f)  # type: ignore[no-any-return]
+            _config_cache = json.load(f)  # type: ignore[no-any-return]
+            return _config_cache.copy()
     except (json.JSONDecodeError, OSError):
+        _config_cache = {}
         return {}
 
 
@@ -42,10 +52,15 @@ def save_config(config: dict[str, Any]) -> None:
     Raises:
         UseCaseError: If saving the configuration file fails.
     """
+    global _config_cache
     config_path = get_config_path()
     try:
-        with open(config_path, "w", encoding="utf-8") as f:
+        # Write atomically: temp file then replace to avoid corruption.
+        tmp_path = config_path.with_suffix(".tmp")
+        with open(tmp_path, "w", encoding="utf-8") as f:
             json.dump(config, f, indent=2)
+        tmp_path.replace(config_path)
+        _config_cache = config.copy()
     except OSError as e:
         raise UseCaseError(f"Failed to save configuration: {e}") from e
 

--- a/pykorf/app/operation/config/preferences.py
+++ b/pykorf/app/operation/config/preferences.py
@@ -36,7 +36,11 @@ def load_config() -> dict[str, Any]:
         return {}
     try:
         with open(config_path, encoding="utf-8") as f:
-            _config_cache = json.load(f)  # type: ignore[no-any-return]
+            data = json.load(f)
+            if isinstance(data, dict):
+                _config_cache = data
+            else:
+                _config_cache = {}
             return _config_cache.copy()
     except (json.JSONDecodeError, OSError):
         _config_cache = {}
@@ -57,10 +61,13 @@ def save_config(config: dict[str, Any]) -> None:
     try:
         # Write atomically: temp file then replace to avoid corruption.
         tmp_path = config_path.with_suffix(".tmp")
-        with open(tmp_path, "w", encoding="utf-8") as f:
-            json.dump(config, f, indent=2)
-        tmp_path.replace(config_path)
-        _config_cache = config.copy()
+        try:
+            with open(tmp_path, "w", encoding="utf-8") as f:
+                json.dump(config, f, indent=2)
+            tmp_path.replace(config_path)
+            _config_cache = config.copy()
+        finally:
+            tmp_path.unlink(missing_ok=True)
     except OSError as e:
         raise UseCaseError(f"Failed to save configuration: {e}") from e
 


### PR DESCRIPTION
- preferences.py: Add _config_cache to avoid reading config.json on every getter call
- preferences.py: Write config atomically via temp file + replace() to prevent corruption
- deps.py: Add persist(model) helper for save+reload pattern used by all mutating endpoints
- deps.py: Add is_real_pipe() predicate to centralize dummy pipe filtering