### PR TITLE
P3: Deduplicate toggle switch CSS, move to global styles

### DIFF
--- a/pykorf/app/frontend/src/style.css
+++ b/pykorf/app/frontend/src/style.css
@@ -212,6 +212,36 @@
   @apply bg-blue-50 text-blue-800 border border-blue-200;
 }
 
+/* ─── Toggle switch ─────────────────────────────────────────────────────────── */
+.form-check-input {
+  width: 2em;
+  height: 1em;
+  border-radius: 1em;
+  appearance: none;
+  background: #adb5bd;
+  cursor: pointer;
+  position: relative;
+  transition: background 0.15s;
+  flex-shrink: 0;
+}
+.form-check-input:checked {
+  background: #3b82f6;
+}
+.form-check-input::after {
+  content: "";
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: calc(1em - 4px);
+  height: calc(1em - 4px);
+  border-radius: 50%;
+  background: white;
+  transition: transform 0.15s;
+}
+.form-check-input:checked::after {
+  transform: translateX(1em);
+}
+
 /* ─── Misc ─────────────────────────────────────────────────────────────────── */
 .pk-font-mono {
   @apply font-mono;

--- a/pykorf/app/frontend/src/style.css
+++ b/pykorf/app/frontend/src/style.css
@@ -214,29 +214,21 @@
 
 /* ─── Toggle switch ─────────────────────────────────────────────────────────── */
 .form-check-input {
+  @apply appearance-none cursor-pointer relative transition-colors shrink-0 rounded-full;
   width: 2em;
   height: 1em;
-  border-radius: 1em;
-  appearance: none;
   background: #adb5bd;
-  cursor: pointer;
-  position: relative;
-  transition: background 0.15s;
-  flex-shrink: 0;
 }
 .form-check-input:checked {
-  background: #3b82f6;
+  @apply bg-blue-500;
 }
 .form-check-input::after {
   content: "";
-  position: absolute;
+  @apply absolute rounded-full bg-white transition-transform;
   top: 2px;
   left: 2px;
   width: calc(1em - 4px);
   height: calc(1em - 4px);
-  border-radius: 50%;
-  background: white;
-  transition: transform 0.15s;
 }
 .form-check-input:checked::after {
   transform: translateX(1em);

--- a/pykorf/app/frontend/src/views/BulkModificationView.vue
+++ b/pykorf/app/frontend/src/views/BulkModificationView.vue
@@ -468,33 +468,4 @@ onMounted(async () => {
 .setting-card-unselected {
   border-color: #dee2e6;
 }
-/* Form toggle switch */
-.form-check-input {
-  width: 2em;
-  height: 1em;
-  border-radius: 1em;
-  appearance: none;
-  background: #adb5bd;
-  cursor: pointer;
-  position: relative;
-  transition: background 0.15s;
-  flex-shrink: 0;
-}
-.form-check-input:checked {
-  background: #3b82f6;
-}
-.form-check-input::after {
-  content: '';
-  position: absolute;
-  top: 2px;
-  left: 2px;
-  width: calc(1em - 4px);
-  height: calc(1em - 4px);
-  border-radius: 50%;
-  background: white;
-  transition: transform 0.15s;
-}
-.form-check-input:checked::after {
-  transform: translateX(1em);
-}
 </style>

--- a/pykorf/app/frontend/src/views/PreferencesView.vue
+++ b/pykorf/app/frontend/src/views/PreferencesView.vue
@@ -558,37 +558,3 @@ onMounted(() => {
   " />
 </template>
 
-<style scoped>
-/* Form toggle switch */
-.form-check-input {
-  width: 2em;
-  height: 1em;
-  border-radius: 1em;
-  appearance: none;
-  background: #adb5bd;
-  cursor: pointer;
-  position: relative;
-  transition: background 0.15s;
-  flex-shrink: 0;
-}
-
-.form-check-input:checked {
-  background: #3b82f6;
-}
-
-.form-check-input::after {
-  content: "";
-  position: absolute;
-  top: 2px;
-  left: 2px;
-  width: calc(1em - 4px);
-  height: calc(1em - 4px);
-  border-radius: 50%;
-  background: white;
-  transition: transform 0.15s;
-}
-
-.form-check-input:checked::after {
-  transform: translateX(1em);
-}
-</style>


### PR DESCRIPTION
- Move .form-check-input toggle switch CSS from BulkModificationView.vue and PreferencesView.vue scoped styles to global style.css
- Reduces CSS duplication across components